### PR TITLE
Ies2

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -293,6 +293,17 @@ if (NOT BUILD_TESTS)
     return ()
 endif()
 
+foreach(name ies_enkf ies_enkf_config ies_enkf_data)
+       add_executable(${name} analysis/modules/tests/${name}.c)
+       target_include_directories(${name} PRIVATE analysis/modules)
+       target_link_libraries(${name} res ies)
+       add_test(NAME ${name} COMMAND ${name})
+endforeach()
+add_executable( ies_module analysis/modules/tests/ies_enkf_module.c )
+target_link_libraries(ies_module res)
+add_test(NAME ies_module COMMAND ies_module $<TARGET_FILE:ies>)
+
+
 foreach(name ert_util_logh
              ert_util_arg_pack
              ert_util_matrix_lapack

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -224,7 +224,9 @@ add_library(rml_enkf SHARED analysis/modules/rml_enkf_config.c
                             )
 
 add_library(ies SHARED analysis/modules/ies_enkf.c
-                       analysis/modules/ies_enkf_config.c)
+                       analysis/modules/ies_enkf_config.c
+                       analysis/modules/ies_enkf_data.c)
+
 
 foreach (module rml_enkf ies)
   target_link_libraries(${module} PRIVATE res ecl ${CMAKE_DL_LIBS})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -221,12 +221,18 @@ add_library(rml_enkf SHARED analysis/modules/rml_enkf_config.c
                             analysis/modules/rml_enkf.c
                             analysis/modules/rml_enkf_common.c
                             analysis/modules/rml_enkf_log.c
-)
-target_link_libraries(rml_enkf PRIVATE res ecl ${CMAKE_DL_LIBS})
-target_include_directories(rml_enkf PRIVATE analysis/modules)
-set_target_properties(rml_enkf PROPERTIES VERSION 1.0
-                                          SOVERSION 1.0
-                                          PREFIX "")
+                            )
+
+add_library(ies SHARED analysis/modules/ies_enkf.c
+                       analysis/modules/ies_enkf_config.c)
+
+foreach (module rml_enkf ies)
+  target_link_libraries(${module} PRIVATE res ecl ${CMAKE_DL_LIBS})
+  target_include_directories(${module} PRIVATE analysis/modules)
+  set_target_properties(${module} PROPERTIES VERSION 1.0
+                                 SOVERSION 1.0
+                                 PREFIX "")
+endforeach()
 
 add_library(std_enkf_debug SHARED analysis/modules/std_enkf_debug.c)
 target_link_libraries(std_enkf_debug PRIVATE res ecl ${CMAKE_DL_LIBS})

--- a/lib/analysis/modules/ies_enkf.c
+++ b/lib/analysis/modules/ies_enkf.c
@@ -39,10 +39,7 @@
 #include <ert/analysis/std_enkf.hpp>
 
 #include "ies_enkf_config.h"
-
-typedef struct ies_enkf_data_struct ies_enkf_data_type;
-
-#define IES_ENKF_TYPE_ID 19640202
+#include "ies_enkf_data.h"
 
 #define ENKF_SUBSPACE_DIMENSION_KEY      "ENKF_SUBSPACE_DIMENSION"
 #define ENKF_TRUNCATION_KEY              "ENKF_TRUNCATION"
@@ -61,245 +58,20 @@ typedef struct ies_enkf_data_struct ies_enkf_data_type;
 //#define DEFAULT_ANALYSIS_SCALE_DATA true
 
 
-//**********************************************
-// IES "object" data definition
-//**********************************************
-/*
-  The configuration data used by the ies_enkf module is contained in a
-  ies_enkf_data_struct instance. The data type used for the ies_enkf
-  module is quite simple; with only a few scalar variables, but there
-  are essentially no limits to what you can pack into such a datatype.
-
-  All the functions in the module have a void pointer as the first
-  argument, this will immediately be casted to an ies_enkf_data_type
-  instance, to get some type safety the UTIL_TYPE_ID system should be
-  used.
-
-  The data structure holding the data for your analysis module should
-  be created and initialized by a constructor, which should be
-  registered with the '.alloc' element of the analysis table; in the
-  same manner the desctruction of this data should be handled by a
-  destructor or free() function registered with the .freef field of
-  the analysis table.
-*/
-
-struct ies_enkf_data_struct {
-   UTIL_TYPE_ID_DECLARATION;
-   int       iteration_nr;            // Keep track of the outer iteration loop
-   double    truncation;              // Controlled by config key: ENKF_TRUNCATION_KEY
-   int       subspace_dimension;      // Controlled by config key: ENKF_SUBSPACE_DIMENSION_KEY (-1: use Truncation instead)
-   double    ies_steplength;          // Step length in Gauss Newton iteration
-   double    gauss_newton_conv;       // NOT USED
-   bool      ies_subspace;            // NOT USED
-   int       ies_inversion;                // 1 for exact R, 2 for R=EE', 3 for E
-   char    * ies_logfile;             // Filename for ies logfile
-   bool      ies_debug;               // True or false for storing debug information
-   int       max_gauss_newton_it;     // NOT USED
-   int state_size;                    // Initial state_size used for checks in subsequent calls
-   bool_vector_type * ens_mask0;      // Initial ensemble mask of active realizations
-   bool_vector_type * ens_mask;       // Ensemble mask of active realizations
-   bool_vector_type * obs_mask0;      // Initial observation mask for active measurements
-   bool_vector_type * obs_mask;       // Current observation mask
-   matrix_type * W;                   // Coefficient matrix used to compute Omega = I + W (I -11'/N)/sqrt(N-1)
-   matrix_type * A0;                  // Prior ensemble used in Ei=A0 Omega_i
-   matrix_type * E;                   // Prior ensemble of measurement perturations (should be the same for all iterations)
-   bool      converged;               // GN has converged
-   ies_enkf_config_type * config;     // This I don't understand but I assume I include data from the ies_enkf_config_type defined in ies_enkf_config.c
-   bool      AAprojection;            // For including the AAprojection of Y
-   FILE*     log_fp;                  // logfile id
-};
-
-static UTIL_SAFE_CAST_FUNCTION( ies_enkf_data , IES_ENKF_TYPE_ID )
-static UTIL_SAFE_CAST_FUNCTION_CONST( ies_enkf_data , IES_ENKF_TYPE_ID )
-
-void * ies_enkf_data_alloc( rng_type * rng) {
-  ies_enkf_data_type * data = util_malloc( sizeof * data);
-  UTIL_TYPE_ID_INIT( data , IES_ENKF_TYPE_ID );
-  data->iteration_nr         = 0;
-  data->truncation           = 0.0;
-  data->subspace_dimension   = 0;
-  data->ies_steplength       = 0.0;
-  data->gauss_newton_conv    = 0.0;
-  data->ies_subspace         = false;
-  data->ies_inversion        = false;
-  data->ies_logfile          = NULL ;
-  data->ies_debug            = false;
-  data->max_gauss_newton_it  = 0;
-  data->state_size           = 0;
-  data->ens_mask0            = NULL;
-  data->ens_mask             = NULL;
-  data->obs_mask0            = NULL;
-  data->obs_mask             = NULL;
-  data->W                    = NULL;
-  data->A0                   = NULL;
-  data->E                    = NULL;
-  data->converged            = false;
-  data->config               = ies_enkf_config_alloc();
-  data->AAprojection         = true;
-  data->log_fp               = NULL;
-  return data;
+static void printf_mask(FILE * log_fp, const char * name, const bool_vector_type * mask) {
+  fputs(name, log_fp);
+  for (int i = 0; i < bool_vector_size(mask); i++){
+    fprintf(log_fp,"%d", bool_vector_iget(mask, i));
+    if ((i+1)%10  == 0)  fputs(" ", log_fp);
+    if ((i+1)%100 == 0)  fputs("\nobsmask_0:", log_fp);
+  }
+  fputs("\n", log_fp);
 }
-
-void ies_enkf_data_free( void * arg ) {
-  ies_enkf_data_type * data = ies_enkf_data_safe_cast( arg );
-  ies_enkf_config_free( data->config );
-  free( data );
-}
-
-void static teccost(const matrix_type * W,
-             const matrix_type * D,
-             const char * fname,
-             const int ens_size,
-             const int izone)
-{
-   FILE *fp;
-   float costJ[100];
-
-   if (izone == 1){
-      fp = fopen(fname, "w");
-      fprintf(fp, "TITLE = \"%s\"\n",fname);
-      fprintf(fp, "VARIABLES = \"i\" \"Average J\" ");
-      for (int i = 0; i < ens_size; i++)
-         fprintf(fp, "\"%d\" ",i);
-      fprintf(fp,"\n");
-   } else {
-      fp = fopen(fname, "a");
-   }
-
-   float costf=0.0;
-   for (int i = 0; i < ens_size; i++){
-      costJ[i]=matrix_column_column_dot_product(W,i,W,i)+matrix_column_column_dot_product(D,i,D,i);
-      costf += costJ[i];
-   }
-   costf= costf/ens_size;
-
-   fprintf(fp,"%2d %10.3f ", izone-1, costf) ;
-   for (int i = 0; i < ens_size; i++)
-      fprintf(fp,"%10.3f ", costJ[i] ) ;
-   fprintf(fp,"\n") ;
-   fclose(fp);
-}
-
-void static teclog(const matrix_type * W,
-            const matrix_type * D,
-            const matrix_type * DW,
-            const char * fname,
-            const int ens_size,
-            const int itnr,
-            const double rcond,
-            const int nrsing,
-            const int nrobs)
-{
-
-   double diff1W = 0.0;
-   double diff2W = 0.0;
-   double diffW;
-   double costfp,costfd,costf;
-   FILE *fp;
-
-   if (itnr == 1){
-      fp = fopen(fname, "w");
-      fprintf(fp, "TITLE = \"%s\"\n",fname);
-      fprintf(fp, "VARIABLES = \"it\" \"Diff1W\" \"Diff2W\" \"J-prior\" \"J-data\" \"J\" \"rcond\" \"Sing\" \"nrobs\"\n");
-   } else {
-      fp = fopen(fname, "a");
-   }
-
-   for (int i = 0; i < ens_size; i++){
-       diffW=matrix_column_column_dot_product(DW,i,DW,i)/ens_size;
-       diff2W+=diffW;
-       if (diffW > diff1W) diff1W=diffW ;
-   }
-   diff2W=diff2W/ens_size;
-
-   costfp=0.0;
-   costfd=0.0;
-   for (int i = 0; i < ens_size; i++){
-       costfp += matrix_column_column_dot_product(W,i,W,i);
-       costfd += matrix_column_column_dot_product(D,i,D,i);
-   }
-   costfp=costfp/ens_size;
-   costfd=costfd/ens_size;
-   costf= costfp + costfd;
-   fprintf(fp," %d %12.5e %12.5e %12.5e %12.5e %12.5e %12.5e %d %d\n", itnr-1, diff1W, diff2W, costfp, costfd, costf, rcond, nrsing , nrobs ) ;
-   fclose(fp);
-}
-
-void static tecfld(const matrix_type * W,
-           const char * fname,
-           const char * vname,
-           int idim,
-           int jdim,
-           int izone)
-{
-   FILE *fp;
-
-   if (izone == 1){
-      fp = fopen(fname, "w");
-      fprintf(fp, "TITLE = \"%s\"\n",fname);
-      fprintf(fp, "VARIABLES = \"i-index\" \"j-index\" \"%s\"\n",vname);
-      fprintf(fp, "ZONE F=BLOCK, T=\"Iteration %d\", I=%d, J=%d, K=1\n",izone, idim, jdim);
-      {
-         int ic=0;
-         for (int j=0;j<jdim;j++){
-            for (int i=0;i<idim;i++){
-               ic=ic+1;
-               fprintf(fp,"%d ",i);
-               if (ic==30){
-                  ic=0;
-                  fprintf(fp,"\n");
-               }
-            }
-         }
-      }
-
-      {
-         int ic=0;
-         for (int j=0;j<jdim;j++){
-            for (int i=0;i<idim;i++){
-               ic=ic+1;
-               fprintf(fp,"%d ",j);
-               if (ic==30){
-                  ic=0;
-                  fprintf(fp,"\n");
-               }
-            }
-         }
-      }
-   } else {
-      fp = fopen(fname, "a");
-      fprintf(fp, "ZONE F=BLOCK, T=\"Iteration %d\", I=%d, J=%d, K=1, VARSHARELIST = ([1,2]=1)",izone, idim, jdim);
-   }
-
-   {
-      int ic=0;
-      for (int j=0;j<jdim;j++){
-         for (int i=0;i<idim;i++){
-            ic=ic+1;
-            fprintf(fp,"%12.5e ",matrix_iget(W , i,j));
-            if (ic==30){
-               ic=0;
-               fprintf(fp,"\n");
-            }
-         }
-      }
-   }
-   fclose(fp);
-}
-
 
 
 /***************************************************************************************************************
 *  Set / Get iteration number
 ****************************************************************************************************************/
-void ies_enkf_set_iteration_nr( ies_enkf_data_type * data , int iteration_nr) {
-  data->iteration_nr = iteration_nr;
-}
-
-int ies_enkf_get_iteration_nr( const ies_enkf_data_type * data ) {
-  return data->iteration_nr;
-}
-
 /*
  * -------------------------------------------------------------------------------------------------------------
  * I E n K S
@@ -318,20 +90,12 @@ void ies_enkf_init_update(void * arg ,
   ies_enkf_data_type * module_data = ies_enkf_data_safe_cast( arg );
 
 /* Store current ens_mask in module_data->ens_mask for each iteration */
-  if (module_data->ens_mask)
-    bool_vector_free( module_data->ens_mask );
-
-  module_data->ens_mask = bool_vector_alloc_copy( ens_mask );
+  ies_enkf_data_update_ens_mask(module_data, ens_mask);
 
 /* Store obs_mask for initial iteration in module_data->obs_mask0,
 *  for each subsequent iteration we store the current mask in module_data->obs_mask */
-  if (!module_data->obs_mask0)
-     module_data->obs_mask0 = bool_vector_alloc_copy( obs_mask );
-
-  if (module_data->obs_mask)
-    bool_vector_free( module_data->obs_mask );
-
-  module_data->obs_mask = bool_vector_alloc_copy( obs_mask );
+  ies_enkf_store_initial_obs_mask(module_data, obs_mask);
+  ies_enkf_update_obs_mask(module_data, obs_mask);
 }
 
 
@@ -354,133 +118,81 @@ void ies_enkf_updateA( void * module_data,
                        rng_type * rng) {
 
    ies_enkf_data_type * data = ies_enkf_data_safe_cast( module_data );
+   const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( data );
+   const bool_vector_type * obs_mask0 = ies_enkf_data_get_obs_mask0( data );
+   const bool_vector_type * obs_mask  = ies_enkf_data_get_obs_mask( data );
+   const bool_vector_type * ens_mask  = ies_enkf_data_get_ens_mask( data );
 
-   int nrobs_msk     =bool_vector_size( data->obs_mask ); // Total number of observations
-   int nrobs_inp     =matrix_get_rows( Yin );             // Number of active observations input in current iteration
-   int nrobs         =nrobs_inp;                          // Number of selected active observations
+   int nrobs_msk     =ies_enkf_data_get_obs_mask_size(data); // Total number of observations
+   int nrobs_inp     =matrix_get_rows( Yin );                // Number of active observations input in current iteration
+   int nrobs         =nrobs_inp;                             // Number of selected active observations
 
 
-   int ens_size_msk  =bool_vector_size(data->ens_mask);   // Total number of realizations
-   int ens_size      =matrix_get_columns( Yin );          // Number of active realizations in current iteration
-
+   int ens_size_msk  = ies_enkf_data_get_ens_mask_size(data);   // Total number of realizations
+   int ens_size      = matrix_get_columns( Yin );               // Number of active realizations in current iteration
    int state_size    = matrix_get_rows( A );
 
+   double ies_steplength = ies_enkf_config_get_ies_steplength(ies_config);
+   int ies_inversion = ies_enkf_config_get_ies_inversion( ies_config );
+   double truncation = ies_enkf_config_get_truncation( ies_config );
+   bool ies_debug = ies_enkf_config_get_ies_debug(ies_config);
+   int subspace_dimension = ies_enkf_config_get_enkf_subspace_dimension( ies_config );
    double rcond;
    int nrsing=0;
+   int iteration_nr = ies_enkf_data_inc_iteration_nr(data);
+   FILE * log_fp;
 
-   if (data->state_size == 0) data->state_size=state_size;
+   ies_enkf_data_update_state_size( data, state_size );
 
-
-   data->iteration_nr         = data->iteration_nr+1 ;
-   data->ies_steplength       = ies_enkf_config_get_ies_steplength( data->config );
-   data->ies_subspace         = ies_enkf_config_get_ies_subspace( data->config );
-   data->ies_inversion        = ies_enkf_config_get_ies_inversion( data->config );
-   data->ies_logfile          = ies_enkf_config_get_ies_logfile( data->config );
-   data->ies_debug            = ies_enkf_config_get_ies_debug( data->config );
-
-   data->truncation           = ies_enkf_config_get_truncation( data->config );
-   data->subspace_dimension   = ies_enkf_config_get_enkf_subspace_dimension( data->config );
-
-   data->gauss_newton_conv    = ies_enkf_config_get_gauss_newton_conv( data->config );
-
-   if (data->iteration_nr > 3) data->ies_steplength=data->ies_steplength/2;
+   if (ies_enkf_data_get_iteration_nr(data) > 3)
+     ies_steplength=ies_steplength/2;
 
 
-   if (data->iteration_nr == 1){
-      data->log_fp=fopen(data->ies_logfile, "w");
-   } else {
-      data->log_fp=fopen(data->ies_logfile, "a");
-   }
+   log_fp = ies_enkf_data_open_log(data);
 
-   fprintf(data->log_fp,"\n\n\n***********************************************************************\n");
-   fprintf(data->log_fp,"IES Iteration   = %d\n", data->iteration_nr);
-   fprintf(data->log_fp,"----ies_steplength  = %f\n", data->ies_steplength);
-   fprintf(data->log_fp,"----ies_inversion   = %d\n", data->ies_inversion);
-   fprintf(data->log_fp,"----ies_debug       = %d\n", data->ies_debug);
-   fprintf(data->log_fp,"----truncation      = %f %d\n", data->truncation, data->subspace_dimension);
-   fprintf(data->log_fp,"----ies_logfile     = %s\n", data->ies_logfile);
-   bool dbg = ies_enkf_config_get_ies_debug( data->config ) ;
+   fprintf(log_fp,"\n\n\n***********************************************************************\n");
+   fprintf(log_fp,"IES Iteration   = %d\n", iteration_nr);
+   fprintf(log_fp,"----ies_steplength  = %f\n", ies_steplength);
+   fprintf(log_fp,"----ies_inversion   = %d\n", ies_inversion);
+   fprintf(log_fp,"----ies_debug       = %d\n", ies_debug);
+   fprintf(log_fp,"----truncation      = %f %d\n", truncation, subspace_dimension);
+   bool dbg = ies_enkf_config_get_ies_debug( ies_config ) ;
 
 /***************************************************************************************************************/
 /* Counting number of active observations for current iteration. The number requires that
    the observations were included in the initial call for storage in data->E as well as in
    in the current call. Thus, it is possible to remove observations but not include new ones. */
-   nrobs=0;
-   for (int i = 0; i < nrobs_msk; i++){
-      if ( bool_vector_iget(data->obs_mask0,i) && bool_vector_iget(data->obs_mask,i) ){
-         nrobs=nrobs+1;
-      }
-   }
-
+   nrobs = ies_enkf_data_active_obs_count(data);
    int nrmin  = util_int_min( ens_size , nrobs);
    double nsc = 1.0/sqrt(ens_size - 1.0);
 
 /* dimensions for printing */
-   int m_nrobs     =util_int_min(nrobs     -1,7);
-   int m_ens_size  =util_int_min(ens_size  -1,16);
-   int m_state_size=util_int_min(state_size-1,3);
+   int m_nrobs      = util_int_min(nrobs     -1,7);
+   int m_ens_size   = util_int_min(ens_size  -1,16);
+   int m_state_size = util_int_min(state_size-1,3);
 
 /***************************************************************************************************************/
-   if (!data->E){
-      // We store the initial observation perturbations corresponding to data->obs_mask0.
-      fprintf(data->log_fp,"Allocating and assigning data->E \n");
-      data->E=matrix_alloc( nrobs , ens_size  );
-      matrix_assign(data->E,Ein);
-      if (dbg) matrix_pretty_fprint_submat(data->E,"data->E","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
-   }
-
-   if (!data->W){
-      // We initialize data-W which will store W for use in next iteration                    (Line 9)
-      fprintf(data->log_fp,"Allocating data->W\n");
-      data->W=matrix_alloc( ens_size , ens_size  );
-      matrix_set(data->W , 0.0) ;
-      if (dbg) matrix_pretty_fprint_submat(data->W,"Ini data->W","%11.5f",data->log_fp,0,m_ens_size,0,m_ens_size) ;
-   }
-
-   if (!data->A0){
-      // We store the initial ensemble to use it in final update equation                     (Line 11)
-      fprintf(data->log_fp,"Allocating and assigning data->A0 \n");
-      data->A0=matrix_alloc( state_size , ens_size  );
-      matrix_assign(data->A0,A);
-      if (dbg) matrix_pretty_fprint_submat(data->A0,"Ini data->A0","%11.5f",data->log_fp,0,m_state_size,0,m_ens_size) ;
-   }
-
+   ies_enkf_data_store_initialE(data, Ein);
+   ies_enkf_data_allocateW(data, ens_size);
+   ies_enkf_data_store_initialA(data, A);
 
 
 /***************************************************************************************************************/
-   fprintf(data->log_fp,"----active ens_size  = %d, total ens_size_msk = %d\n", ens_size,ens_size_msk);
-   fprintf(data->log_fp,"----active nrobs     = %d, nrobs_inp= %d, total nrobs_msk= %d\n", nrobs, nrobs_inp, nrobs_msk );
-   fprintf(data->log_fp,"----active state_size= %d\n", state_size );
+   fprintf(log_fp,"----active ens_size  = %d, total ens_size_msk = %d\n", ens_size,ens_size_msk);
+   fprintf(log_fp,"----active nrobs     = %d, nrobs_inp= %d, total nrobs_msk= %d\n", nrobs, nrobs_inp, nrobs_msk );
+   fprintf(log_fp,"----active state_size= %d\n", state_size );
 
 /***************************************************************************************************************/
 /* Print initial observation mask */
-   fprintf(data->log_fp,"obsmask_0:") ;
-   for (int i = 0; i < nrobs_msk; i++){
-      fprintf(data->log_fp,"%d",bool_vector_iget(data->obs_mask0,i));
-      if ((i+1)%10 == 0) fprintf(data->log_fp," ") ;
-      if ((i+1)%100 == 0) fprintf(data->log_fp,"\nobsmask_0:") ;
-   }
-   fprintf(data->log_fp,"\n");
+   printf_mask(log_fp, "obsmask_0:", ies_enkf_data_get_obs_mask0(data));
 
 /***************************************************************************************************************/
 /* Print Current observation mask */
-   fprintf(data->log_fp,"obsmask_i:") ;
-   for (int i = 0; i < nrobs_msk; i++){
-      fprintf(data->log_fp,"%d",bool_vector_iget(data->obs_mask,i));
-      if ((i+1)%10 == 0) fprintf(data->log_fp," ") ;
-      if ((i+1)%100 == 0) fprintf(data->log_fp,"\nobsmask_i:") ;
-   }
-   fprintf(data->log_fp,"\n");
+   printf_mask(log_fp, "obsmask_i:", ies_enkf_data_get_obs_mask(data));
 
 /***************************************************************************************************************/
 /* Print Current ensemble mask */
-   fprintf(data->log_fp,"ensmask_i:");
-   for (int i = 0; i < ens_size_msk; i++){
-      fprintf(data->log_fp,"%d",bool_vector_iget(data->ens_mask,i));
-      if ((i+1)%10 == 0) fprintf(data->log_fp," ") ;
-      if ((i+1)%100 == 0) fprintf(data->log_fp,"\n") ;
-   }
-   fprintf(data->log_fp,"\n\n");
+   printf_mask(log_fp, "ensmask_i:", ies_enkf_data_get_ens_mask(data));
 
 /***************************************************************************************************************
 * Re structure input matrices according to new active obs_mask and ens_size.
@@ -498,50 +210,58 @@ void ies_enkf_updateA( void * module_data,
    matrix_inplace_sub(Din,Ein);
 
 /* E=data->E but only using the active obs also stored in data->E */
-   int j=-1;  // counter for initial mask0
-   int k=-1;  // counter for current mask
-   int m=-1;  // counter for currently active measurements
-   for (int iobs = 0; iobs < nrobs_msk; iobs++){
-      if ( bool_vector_iget(data->obs_mask0,iobs) )
+   {
+     const bool_vector_type * obs_mask0 = ies_enkf_data_get_obs_mask0(data);
+     const bool_vector_type * obs_mask  = ies_enkf_data_get_obs_mask(data);
+     const bool_vector_type * ens_mask  = ies_enkf_data_get_ens_mask(data);
+     const matrix_type * dataE          = ies_enkf_data_getE(data);
+
+     int j=-1;  // counter for initial mask0
+     int k=-1;  // counter for current mask
+     int m=-1;  // counter for currently active measurements
+     for (int iobs = 0; iobs < nrobs_msk; iobs++){
+       if ( bool_vector_iget(obs_mask0,iobs) )
          j=j+1 ;
 
-      if ( bool_vector_iget(data->obs_mask,iobs) )
+       if ( bool_vector_iget(obs_mask,iobs) )
          k=k+1 ;
 
-      if ( bool_vector_iget(data->obs_mask0,iobs) && bool_vector_iget(data->obs_mask,iobs) ){
+       if ( bool_vector_iget(obs_mask0,iobs) && bool_vector_iget(obs_mask,iobs) ){
          m=m+1;
 
          {
-            int i=-1;
-            for (int iens = 0; iens < ens_size_msk; iens++){
-               if ( bool_vector_iget(data->ens_mask,iens) ){
-                  i=i+1 ;
-                  matrix_iset_safe(E,m,i,matrix_iget(data->E,j,iens)) ;
-               }
-            }
+           int i=-1;
+           for (int iens = 0; iens < ens_size_msk; iens++){
+             if ( bool_vector_iget(ens_mask,iens) ){
+               i=i+1 ;
+               matrix_iset_safe(E,m,i,matrix_iget(dataE,j,iens)) ;
+             }
+           }
          }
 
          matrix_copy_row(D,Din,m,k);
          matrix_copy_row(Y,Yin,m,k);
          matrix_copy_row(Rtmp,Rin,m,k);
          matrix_copy_column(R,Rtmp,m,k);
-      }
+       }
+     }
+
+     if (ens_size_msk == ens_size && nrobs == nrobs_inp){
+       fprintf(log_fp,"data->E copied exactly to E: %d\n",matrix_equal(dataE,E)) ;
+     }
    }
-   if (ens_size_msk == ens_size && nrobs == nrobs_inp){
-      fprintf(data->log_fp,"data->E copied exactly to E: %d\n",matrix_equal(data->E,E)) ;
-   }
 
-   fprintf(data->log_fp,"Input matrices\n");
-   if (dbg) matrix_pretty_fprint_submat(E,"E","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
+   fprintf(log_fp,"Input matrices\n");
+   if (dbg) matrix_pretty_fprint_submat(E,"E","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
 
-   if (dbg) matrix_pretty_fprint_submat(Din,"Din","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
-   if (dbg) matrix_pretty_fprint_submat(D,"D","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint_submat(Din,"Din","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint_submat(D,"D","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
 
-   if (dbg) matrix_pretty_fprint_submat(Yin,"Yin","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
-   if (dbg) matrix_pretty_fprint_submat(Y,"Y","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint_submat(Yin,"Yin","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint_submat(Y,"Y","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
 
-   if (dbg) matrix_pretty_fprint_submat(Rin,"Rin","%11.5f",data->log_fp,0,m_nrobs,0,m_nrobs) ;
-   if (dbg) matrix_pretty_fprint_submat(R,"R","%11.5f",data->log_fp,0,m_nrobs,0,m_nrobs) ;
+   if (dbg) matrix_pretty_fprint_submat(Rin,"Rin","%11.5f",log_fp,0,m_nrobs,0,m_nrobs) ;
+   if (dbg) matrix_pretty_fprint_submat(R,"R","%11.5f",log_fp,0,m_nrobs,0,m_nrobs) ;
 
    matrix_inplace_add(D,E);          // Add old measurement perturbations
 
@@ -563,61 +283,63 @@ void ies_enkf_updateA( void * module_data,
    double      * eig = (double*)util_calloc( ens_size , sizeof * eig);
 
 
-   if (dbg) matrix_pretty_fprint_submat(A,"Ain","%11.5f",data->log_fp,0,m_state_size,0,m_ens_size) ;
-   if (dbg) fprintf(data->log_fp,"Computed matrices\n");
+   if (dbg) matrix_pretty_fprint_submat(A,"Ain","%11.5f",log_fp,0,m_state_size,0,m_ens_size) ;
+   if (dbg) fprintf(log_fp,"Computed matrices\n");
 
 /***************************************************************************************************************
 *  Subtract mean of predictions to generate predicted ensemble anomaly matrix                 (Line 5)
 */
    matrix_subtract_row_mean( Y );   // Y=Y*(I-(1/ens_size)*11)
    matrix_scale(Y,nsc);             // Y=Y / sqrt(ens_size-1)
-   if (dbg) matrix_pretty_fprint_submat(Y,"Y","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint_submat(Y,"Y","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
 
 
 /***************************************************************************************************************
 *  COMPUTING THE PROJECTION Y= Y * (Ai^+ * Ai) (only used when state_size < ens_size-1)    */
-   if (data->AAprojection && state_size <= ens_size -1){
-      fprintf(data->log_fp,"Activating AAi projection for Y\n");
+   if (ies_enkf_data_get_AAprojection(data) && (state_size <= (ens_size - 1))) {
+      fprintf(log_fp,"Activating AAi projection for Y\n");
       matrix_type * Ai    = matrix_alloc_copy( A );
       matrix_type * AAi   = matrix_alloc( ens_size, ens_size  );
       matrix_subtract_row_mean(Ai);
       matrix_type * VT    = matrix_alloc( state_size, ens_size  );
       matrix_dgesvd(DGESVD_NONE , DGESVD_MIN_RETURN , Ai , eig , NULL , VT);
-      if (dbg) matrix_pretty_fprint_submat(VT,"VT","%11.5f",data->log_fp,0,state_size-1,0,m_ens_size) ;
+      if (dbg) matrix_pretty_fprint_submat(VT,"VT","%11.5f",log_fp,0,state_size-1,0,m_ens_size) ;
       matrix_dgemm(AAi,VT,VT,true,false,1.0,0.0);
-      if (dbg) matrix_pretty_fprint_submat(AAi,"AAi","%11.5f",data->log_fp,0,m_ens_size,0,m_ens_size) ;
+      if (dbg) matrix_pretty_fprint(AAi,"AAi","%11.5f",log_fp);
       matrix_inplace_matmul(Y,AAi);
       matrix_free(Ai);
       matrix_free(AAi);
       matrix_free(VT);
-      if (dbg) matrix_pretty_fprint_submat(Y,"Yprojected","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
+      if (dbg) matrix_pretty_fprint(Y,"Yprojected","%11.5f",log_fp);
    }
 
 /***************************************************************************************************************
 *  COPY ACTIVE REALIZATIONS FROM data->W to W0 */
    {
+      const bool_vector_type * ens_mask = ies_enkf_data_get_ens_mask(data);
+      const matrix_type * dataW = ies_enkf_data_getW(data);
       int i=-1;
       int j;
       for (int iens=0; iens < ens_size_msk; iens++){
-         if ( bool_vector_iget(data->ens_mask,iens) ){
+         if ( bool_vector_iget(ens_mask,iens) ){
             i=i+1;
             j=-1;
             for (int jens=0; jens < ens_size_msk; jens++){
-               if ( bool_vector_iget(data->ens_mask,jens) ){
+               if ( bool_vector_iget(ens_mask,jens) ){
                   j=j+1;
-                  matrix_iset_safe(W0,i,j,matrix_iget(data->W,iens,jens)) ;
+                  matrix_iset_safe(W0,i,j,matrix_iget(dataW,iens,jens)) ;
                }
             }
          }
       }
-   }
 
-   if (ens_size_msk == ens_size){
-      fprintf(data->log_fp,"data->W copied exactly to W0: %d\n",matrix_equal(data->W,W0)) ;
-   }
-   if (dbg) matrix_pretty_fprint_submat(data->W,"data->W","%11.5f",data->log_fp,0,m_ens_size,0,m_ens_size) ;
-   if (dbg) matrix_pretty_fprint_submat(W0,"W0","%11.5f",data->log_fp,0,m_ens_size,0,m_ens_size) ;
+      if (ens_size_msk == ens_size){
+        fprintf(log_fp,"data->W copied exactly to W0: %d\n",matrix_equal(dataW,W0)) ;
+      }
 
+      if (dbg) matrix_pretty_fprint(dataW,"data->W","%11.5f",log_fp);
+      if (dbg) matrix_pretty_fprint(W0,"W0","%11.5f",log_fp);
+   }
 
 /***************************************************************************************************************
 * COMPUTE  X= I + W (I-11'/sqrt(ens_size))    from Eq. (36).                                   (Line 6)
@@ -633,31 +355,31 @@ void ies_enkf_updateA( void * module_data,
    for (int i = 0; i < ens_size; i++){  // X=X+I
       matrix_iadd(X,i,i,1.0);
    }
-   if (dbg) matrix_pretty_fprint_submat(X,"OmegaT","%11.5f",data->log_fp,0,m_ens_size,0,m_ens_size) ;
-   if (dbg) tecfld( X, "tecOmega.dat" , "Omega", ens_size, ens_size , data->iteration_nr);
+   if (dbg) matrix_pretty_fprint_submat(X,"OmegaT","%11.5f",log_fp,0,m_ens_size,0,m_ens_size) ;
+   if (dbg) tecfld( X, "tecOmega.dat" , "Omega", ens_size, ens_size , iteration_nr);
    matrix_transpose(Y,YT);         // RHS stored in YT
 
 /* Solve system and return S in YT                                                             (Line 7)   */
-   fprintf(data->log_fp,"Solving X' S' = Y' using LU factorization:\n");
+   fprintf(log_fp,"Solving X' S' = Y' using LU factorization:\n");
    matrix_dgesvx(X,YT,&rcond);
-   fprintf(data->log_fp,"dgesvx condition number= %12.5e\n",rcond);
+   fprintf(log_fp,"dgesvx condition number= %12.5e\n",rcond);
 
    matrix_transpose(YT,S);          // Copy solution to S
 
 
-   if (data->iteration_nr == 1){
-         fprintf(data->log_fp,"dgesvx: Y exactly equal to S: %d\n",matrix_equal(Y,S)) ;
+   if (iteration_nr == 1){
+         fprintf(log_fp,"dgesvx: Y exactly equal to S: %d\n",matrix_equal(Y,S)) ;
    }
 
 
-   if (dbg) matrix_pretty_fprint_submat(S,"S","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint_submat(S,"S","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
 
 /***************************************************************************************************************
 *  INNOVATION H = S*W + D - Y   from Eq. (47)                                                  (Line 8)    */
    matrix_assign(H,D) ;                            // H=D=dobs + E - Y
    matrix_dgemm(H,S,W0,false,false,1.0,1.0);       // H=S*W + H
 
-   if (dbg) matrix_pretty_fprint_submat(H,"H","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint_submat(H,"H","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
 
 /* Store previous W for convergence test */
    matrix_assign(W,W0);
@@ -688,54 +410,54 @@ void ies_enkf_updateA( void * module_data,
    ies_inversion=3  -> subspace inversion from (a) with R represented by E
 */
 
-   if (data->ies_inversion > 0){
-      fprintf(data->log_fp,"Subspace inversion. (ies_inversion=%d)\n",data->ies_inversion);
+   if (ies_inversion > 0){
+      fprintf(log_fp,"Subspace inversion. (ies_inversion=%d)\n",ies_inversion);
       matrix_type * X1  = matrix_alloc( nrobs   , nrmin     );   // Used in subspace inversion
       matrix_type * X3  = matrix_alloc( nrobs   , ens_size  );   // Used in subspace inversion
-      if (data->ies_inversion == 3){
-         fprintf(data->log_fp,"Subspace inversion using E to represent errors. (ies_inversion=%d)\n",data->ies_inversion);
+      if (ies_inversion == 3){
+         fprintf(log_fp,"Subspace inversion using E to represent errors. (ies_inversion=%d)\n",ies_inversion);
          matrix_scale(E,nsc);
-         enkf_linalg_lowrankE( S , E , X1 , eig , data->truncation , data->subspace_dimension);
-      } else if (data->ies_inversion == 2){
-         fprintf(data->log_fp,"Subspace inversion using ensemble generated full R=EE. (ies_inversion=%d)'\n",data->ies_inversion);
+         enkf_linalg_lowrankE( S , E , X1 , eig , truncation , subspace_dimension);
+      } else if (ies_inversion == 2){
+         fprintf(log_fp,"Subspace inversion using ensemble generated full R=EE. (ies_inversion=%d)'\n",ies_inversion);
          matrix_scale(E,nsc);
          matrix_type * Et = matrix_alloc_transpose( E );
          matrix_type * Cee = matrix_alloc_matmul( E , Et );
          matrix_scale(Cee,nsc*nsc); // since enkf_linalg_lowrankCinv solves (SS' + (N-1) R)^{-1}
-         if (dbg) matrix_pretty_fprint_submat(Cee,"Cee","%11.5f",data->log_fp,0,m_nrobs,0,m_nrobs) ;
-         enkf_linalg_lowrankCinv( S , Cee , X1 , eig , data->truncation , data->subspace_dimension);
+         if (dbg) matrix_pretty_fprint_submat(Cee,"Cee","%11.5f",log_fp,0,m_nrobs,0,m_nrobs) ;
+         enkf_linalg_lowrankCinv( S , Cee , X1 , eig , truncation , subspace_dimension);
          matrix_free( Et );
          matrix_free( Cee );
-      } else if (data->ies_inversion == 1){
-         fprintf(data->log_fp,"Subspace inversion using 'exact' full R. (ies_inversion=%d)\n",data->ies_inversion);
+      } else if (ies_inversion == 1){
+         fprintf(log_fp,"Subspace inversion using 'exact' full R. (ies_inversion=%d)\n",ies_inversion);
          matrix_scale(R,nsc*nsc); // since enkf_linalg_lowrankCinv solves (SS' + (N-1) R)^{-1}
-         if (dbg) matrix_pretty_fprint_submat(R,"R","%11.5f",data->log_fp,0,m_nrobs,0,m_nrobs) ;
-         enkf_linalg_lowrankCinv( S , R , X1 , eig , data->truncation , data->subspace_dimension);
+         if (dbg) matrix_pretty_fprint_submat(R,"R","%11.5f",log_fp,0,m_nrobs,0,m_nrobs) ;
+         enkf_linalg_lowrankCinv( S , R , X1 , eig , truncation , subspace_dimension);
       }
 
       nrsing=0;
-      fprintf(data->log_fp,"\nEig:\n");
+      fprintf(log_fp,"\nEig:\n");
       for (int i=0;i<nrmin;i++){
-         fprintf(data->log_fp," %f ", eig[i]);
-         if ((i+1)%20 == 0) fprintf(data->log_fp,"\n") ;
+         fprintf(log_fp," %f ", eig[i]);
+         if ((i+1)%20 == 0) fprintf(log_fp,"\n") ;
          if (eig[i] < 1.0) nrsing+=1;
       }
-      fprintf(data->log_fp,"\n");
+      fprintf(log_fp,"\n");
 
 /*    X3 = X1 * diag(eig) * X1' * H (Similar to Eq. 14.31, Evensen (2007))                                  */
       enkf_linalg_genX3(X3 , X1 , H , eig);
 
-      if (dbg) matrix_pretty_fprint_submat(X1,"X1","%11.5f",data->log_fp,0,m_nrobs,0,util_int_min(m_nrobs,nrmin-1)) ;
-      if (dbg) matrix_pretty_fprint_submat(X3,"X3","%11.5f",data->log_fp,0,m_nrobs,0,m_ens_size) ;
+      if (dbg) matrix_pretty_fprint_submat(X1,"X1","%11.5f",log_fp,0,m_nrobs,0,util_int_min(m_nrobs,nrmin-1)) ;
+      if (dbg) matrix_pretty_fprint_submat(X3,"X3","%11.5f",log_fp,0,m_nrobs,0,m_ens_size) ;
 
 /*    Update data->W = (1-ies_steplength) * data->W +  ies_steplength * S' * X3                          (Line 9)    */
-      matrix_dgemm(W0 , S , X3 , true , false , data->ies_steplength , 1.0-data->ies_steplength);
+      matrix_dgemm(W0 , S , X3 , true , false , ies_steplength , 1.0-ies_steplength);
 
       matrix_free( X1 );
       matrix_free( X3 );
 
-   } else if (data->ies_inversion == 0) {
-      fprintf(data->log_fp,"Exact inversion using diagonal R=I. (ies_inversion=%d)\n",data->ies_inversion);
+   } else if (ies_inversion == 0) {
+      fprintf(log_fp,"Exact inversion using diagonal R=I. (ies_inversion=%d)\n",ies_inversion);
       matrix_type * Z      = matrix_alloc( ens_size , ens_size  );  // Eigen vectors of S'S+I
       matrix_type * StH    = matrix_alloc( ens_size , ens_size );
       matrix_type * StS    = matrix_alloc( ens_size , ens_size );
@@ -753,15 +475,15 @@ void ies_enkf_updateA( void * module_data,
          matrix_scale_row(ZtStH,i,eig[i]);
       }
 
-      fprintf(data->log_fp,"\nEig:\n");
+      fprintf(log_fp,"\nEig:\n");
       for (int i=0;i<ens_size;i++){
-         fprintf(data->log_fp," %f ", eig[i]);
-         if ((i+1)%20 == 0) fprintf(data->log_fp,"\n") ;
+         fprintf(log_fp," %f ", eig[i]);
+         if ((i+1)%20 == 0) fprintf(log_fp,"\n") ;
       }
-      fprintf(data->log_fp,"\n");
+      fprintf(log_fp,"\n");
 
 /*    Update data->W = (1-ies_steplength) * data->W +  ies_steplength * Z * (Lamda^{-1}) Z' S' H         (Line 9)    */
-      matrix_dgemm(W0 , Z , ZtStH , false , false , data->ies_steplength , 1.0-data->ies_steplength);
+      matrix_dgemm(W0 , Z , ZtStH , false , false , ies_steplength , 1.0-ies_steplength);
 
       matrix_free(Z);
       matrix_free(StH);
@@ -769,7 +491,7 @@ void ies_enkf_updateA( void * module_data,
       matrix_free(ZtStH);
    }
 
-   if (dbg) matrix_pretty_fprint_submat(W0,"Updated W","%11.5f",data->log_fp,0,m_ens_size,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint_submat(W0,"Updated W","%11.5f",log_fp,0,m_ens_size,0,m_ens_size) ;
 
 
 
@@ -777,25 +499,28 @@ void ies_enkf_updateA( void * module_data,
    {
       int i=-1;
       int j;
-      matrix_set(data->W , 0.0) ;
+      matrix_type * dataW = ies_enkf_data_getW(data);
+      const bool_vector_type * ens_mask = ies_enkf_data_get_ens_mask(data);
+      matrix_set(dataW , 0.0) ;
       for (int iens=0; iens < ens_size_msk; iens++){
-         if ( bool_vector_iget(data->ens_mask,iens) ){
+         if ( bool_vector_iget(ens_mask,iens) ){
             i=i+1;
             j=-1;
             for (int jens=0; jens < ens_size_msk; jens++){
-               if ( bool_vector_iget(data->ens_mask,jens) ){
+               if ( bool_vector_iget(ens_mask,jens) ){
                   j=j+1;
-                  matrix_iset_safe(data->W,iens,jens,matrix_iget(W0,i,j)) ;
+                  matrix_iset_safe(dataW,iens,jens,matrix_iget(W0,i,j)) ;
                }
             }
          }
       }
-   }
-   if (ens_size_msk == ens_size){
-      fprintf(data->log_fp,"W0 copied exactly to data->W: %d\n",matrix_equal(data->W,W0)) ;
+
+      if (ens_size_msk == ens_size){
+        fprintf(log_fp,"W0 copied exactly to data->W: %d\n",matrix_equal(dataW,W0)) ;
+      }
    }
 
-   if (dbg) tecfld( W, "tecW.dat" , "W", ens_size, ens_size , data->iteration_nr);
+   if (dbg) tecfld( W, "tecW.dat" , "W", ens_size, ens_size , iteration_nr);
 
 
 /***************************************************************************************************************
@@ -806,43 +531,43 @@ void ies_enkf_updateA( void * module_data,
    for (int i = 0; i < ens_size; i++){
       matrix_iadd(X,i,i,1.0);
    }
-   if (dbg) matrix_pretty_fprint_submat(X,"X","%11.5f",data->log_fp,0,m_ens_size,0,m_ens_size) ;
+   if (dbg) matrix_pretty_fprint(X,"X","%11.5f",log_fp);
 
 /***************************************************************************************************************
 *  COMPUTE NEW ENSEMBLE SOLUTION FOR CURRENT ITERATION  Ei=A0*X                              (Line 11)   */
-   matrix_pretty_fprint_submat(data->A0,"data->A0","%11.5f",data->log_fp,0,m_state_size,0,m_ens_size) ;
-   matrix_pretty_fprint_submat(A,"A^f","%11.5f",data->log_fp,0,m_state_size,0,m_ens_size) ;
 
    {
       int i=-1;
+      const bool_vector_type * ens_mask = ies_enkf_data_get_ens_mask(data);
+      const matrix_type * dataA0 = ies_enkf_data_getA0(data);
+      matrix_pretty_fprint(A0,"data->A0","%11.5f",log_fp);
+      matrix_pretty_fprint(A,"A^f","%11.5f",log_fp);
       for (int iens=0; iens < ens_size_msk; iens++){
-         if ( bool_vector_iget(data->ens_mask,iens) ){
+         if ( bool_vector_iget(ens_mask,iens) ){
             i=i+1;
-            matrix_copy_column(A0,data->A0,i,iens);
+            matrix_copy_column(A0,dataA0,i,iens);
          }
       }
-   }
-   if (ens_size_msk == ens_size){
-      fprintf(data->log_fp,"data->A0 copied exactly to A0: %d\n",matrix_equal(data->A0,A0)) ;
-   }
 
-   if (dbg) tecfld( X, "tecX.dat" , "X", ens_size, ens_size , data->iteration_nr);
+      if (ens_size_msk == ens_size){
+        fprintf(log_fp,"data->A0 copied exactly to A0: %d\n",matrix_equal(dataA0,A0)) ;
+      }
+   }
+   if (dbg) tecfld( X, "tecX.dat" , "X", ens_size, ens_size , iteration_nr);
    matrix_matmul(A,A0,X);
-   matrix_pretty_fprint_submat(A,"A^a","%11.5f",data->log_fp,0,m_state_size,0,m_ens_size) ;
+   matrix_pretty_fprint(A,"A^a","%11.5f",log_fp);
 
 
 /***************************************************************************************************************
 *  COMPUTE ||W0 - W|| AND EVALUATE COST FUNCTION FOR PREVIOUS ITERATE                        (Line 12)   */
    matrix_sub(DW,W0,W);
-   if (dbg) tecfld( DW, "tecDW.dat" , "Delta W", ens_size, ens_size , data->iteration_nr);
-   teclog(W,D,DW,"iesteclog.dat",ens_size,data->iteration_nr, rcond, nrsing, nrobs);
-   teccost(W,D,"costf.dat",ens_size,data->iteration_nr);
+   if (dbg) tecfld( DW, "tecDW.dat" , "Delta W", ens_size, ens_size , iteration_nr);
+   teclog(W,D,DW,"iesteclog.dat",ens_size,iteration_nr, rcond, nrsing, nrobs);
+   teccost(W,D,"costf.dat",ens_size,iteration_nr);
 
 /* DONE *********************************************************************************************************/
 
-
-   fflush(data->log_fp);
-   fclose(data->log_fp);
+   ies_enkf_data_fclose_log(data);
 
    matrix_free( Y  );
    matrix_free( D  );
@@ -871,15 +596,16 @@ void ies_enkf_updateA( void * module_data,
 //**********************************************
 bool ies_enkf_set_int( void * arg , const char * var_name , int value) {
   ies_enkf_data_type * module_data = ies_enkf_data_safe_cast( arg );
+  const ies_enkf_config_type * config = ies_enkf_data_get_config( module_data );
   {
     bool name_recognized = true;
 
     if (strcmp( var_name , ENKF_SUBSPACE_DIMENSION_KEY) == 0)
-      ies_enkf_config_set_enkf_subspace_dimension(module_data->config , value);
+      ies_enkf_config_set_enkf_subspace_dimension(config , value);
     else if (strcmp( var_name , ITER_KEY) == 0)
-      ies_enkf_set_iteration_nr( module_data , value );
+      ies_enkf_data_set_iteration_nr( module_data , value );
     else if (strcmp( var_name , IES_INVERSION_KEY) == 0)
-      ies_enkf_config_set_ies_inversion( module_data->config , value );
+      ies_enkf_config_set_ies_inversion( config , value );
     else
       name_recognized = false;
 
@@ -889,13 +615,14 @@ bool ies_enkf_set_int( void * arg , const char * var_name , int value) {
 
 int ies_enkf_get_int( const void * arg, const char * var_name) {
   const ies_enkf_data_type * module_data = ies_enkf_data_safe_cast_const( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
     if (strcmp(var_name , ITER_KEY) == 0)
-      return ies_enkf_get_iteration_nr(module_data);
+      return ies_enkf_data_get_iteration_nr(module_data);
     else if (strcmp(var_name , ENKF_SUBSPACE_DIMENSION_KEY) == 0)
-      return ies_enkf_config_get_enkf_subspace_dimension(module_data->config);
+      return ies_enkf_config_get_enkf_subspace_dimension(ies_config);
     else if (strcmp(var_name , IES_INVERSION_KEY) == 0)
-      return ies_enkf_config_get_ies_inversion(module_data->config);
+      return ies_enkf_config_get_ies_inversion(ies_config);
     else
       return -1;
   }
@@ -903,11 +630,12 @@ int ies_enkf_get_int( const void * arg, const char * var_name) {
 
 bool ies_enkf_set_string( void * arg , const char * var_name , const char * value) {
   ies_enkf_data_type * module_data = ies_enkf_data_safe_cast( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
     bool name_recognized = true;
 
     if (strcmp( var_name , IES_LOGFILE_KEY) == 0)
-      ies_enkf_config_set_ies_logfile( module_data->config , value );
+      ies_enkf_config_set_ies_logfile( ies_config , value );
     else
       name_recognized = false;
 
@@ -917,10 +645,10 @@ bool ies_enkf_set_string( void * arg , const char * var_name , const char * valu
 
 const char* ies_enkf_get_string( void * arg , const char * var_name ) {
   ies_enkf_data_type * module_data = ies_enkf_data_safe_cast( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
     if (strcmp( var_name , IES_LOGFILE_KEY) == 0)
-      return ies_enkf_config_get_ies_logfile( module_data->config );
-
+      return ies_enkf_config_get_ies_logfile( ies_config );
     else
        return NULL;
   }
@@ -928,13 +656,14 @@ const char* ies_enkf_get_string( void * arg , const char * var_name ) {
 
 bool ies_enkf_set_bool( void * arg , const char * var_name , bool value) {
   ies_enkf_data_type * module_data = ies_enkf_data_safe_cast( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
     bool name_recognized = true;
 
     if (strcmp( var_name , IES_SUBSPACE_KEY) == 0)
-      ies_enkf_config_set_ies_subspace( module_data->config , value);
+      ies_enkf_config_set_ies_subspace( ies_config , value);
     else if (strcmp( var_name , IES_DEBUG_KEY) == 0)
-      ies_enkf_config_set_ies_debug( module_data->config , value );
+      ies_enkf_config_set_ies_debug( ies_config , value );
     else
       name_recognized = false;
 
@@ -944,11 +673,12 @@ bool ies_enkf_set_bool( void * arg , const char * var_name , bool value) {
 
 bool ies_enkf_get_bool( const void * arg, const char * var_name) {
   const ies_enkf_data_type * module_data = ies_enkf_data_safe_cast_const( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
     if (strcmp(var_name , IES_SUBSPACE_KEY) == 0)
-      return ies_enkf_config_get_ies_subspace( module_data->config );
+      return ies_enkf_config_get_ies_subspace( ies_config );
     else if (strcmp(var_name , IES_DEBUG_KEY) == 0)
-      return ies_enkf_config_get_ies_debug( module_data->config );
+      return ies_enkf_config_get_ies_debug( ies_config );
     else
        return false;
   }
@@ -959,15 +689,16 @@ bool ies_enkf_get_bool( const void * arg, const char * var_name) {
 
 bool ies_enkf_set_double( void * arg , const char * var_name , double value) {
   ies_enkf_data_type * module_data = ies_enkf_data_safe_cast( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
     bool name_recognized = true;
 
     if (strcmp( var_name , ENKF_TRUNCATION_KEY) == 0)
-      ies_enkf_config_set_truncation( module_data->config , value );
+      ies_enkf_config_set_truncation( ies_config , value );
     else if (strcmp( var_name , IES_STEPLENGTH_KEY) == 0)
-      ies_enkf_config_set_ies_steplength( module_data->config , value );
+      ies_enkf_config_set_ies_steplength( ies_config , value );
     else if (strcmp( var_name , GAUSS_NEWTON_CONV_KEY) == 0)
-      ies_enkf_config_set_gauss_newton_conv( module_data->config , value );
+      ies_enkf_config_set_gauss_newton_conv( ies_config , value );
     else
       name_recognized = false;
 
@@ -977,15 +708,16 @@ bool ies_enkf_set_double( void * arg , const char * var_name , double value) {
 
 double ies_enkf_get_double( const void * arg, const char * var_name) {
   const ies_enkf_data_type * module_data = ies_enkf_data_safe_cast_const( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
     if (strcmp(var_name , ENKF_TRUNCATION_KEY) == 0)
-      return ies_enkf_config_get_truncation( module_data->config );
+      return ies_enkf_config_get_truncation( ies_config );
 
     if (strcmp(var_name , IES_STEPLENGTH_KEY) == 0)
-      return ies_enkf_config_get_ies_steplength(module_data->config);
+      return ies_enkf_config_get_ies_steplength(ies_config);
 
     if (strcmp(var_name , GAUSS_NEWTON_CONV_KEY) == 0)
-      return ies_enkf_config_get_gauss_newton_conv(module_data->config);
+      return ies_enkf_config_get_gauss_newton_conv(ies_config);
 
     return -1;
   }
@@ -994,8 +726,9 @@ double ies_enkf_get_double( const void * arg, const char * var_name) {
 
 long ies_enkf_get_options( void * arg , long flag ) {
   ies_enkf_data_type * module_data = ies_enkf_data_safe_cast( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
-    return ies_enkf_config_get_option_flags( module_data->config );
+    return ies_enkf_config_get_option_flags( ies_config );
   }
 }
 
@@ -1026,9 +759,10 @@ bool ies_enkf_has_var( const void * arg, const char * var_name) {
 
 void * ies_enkf_get_ptr( const void * arg , const char * var_name ) {
   const ies_enkf_data_type * module_data = ies_enkf_data_safe_cast_const( arg );
+  const ies_enkf_config_type * ies_config = ies_enkf_data_get_config( module_data );
   {
     if (strcmp(var_name , IES_LOGFILE_KEY) == 0)
-      return (void *) ies_enkf_config_get_ies_logfile( module_data->config );
+      return (void *) ies_enkf_config_get_ies_logfile( ies_config );
     else
       return NULL;
   }

--- a/lib/analysis/modules/ies_enkf.c
+++ b/lib/analysis/modules/ies_enkf.c
@@ -55,6 +55,9 @@ typedef struct ies_enkf_data_struct ies_enkf_data_type;
 #define IES_LOGFILE_KEY                  "IES_LOGFILE"
 #define IES_DEBUG_KEY                    "IES_DEBUG"
 
+
+#include "tecplot.c"
+
 //#define DEFAULT_ANALYSIS_SCALE_DATA true
 
 

--- a/lib/analysis/modules/ies_enkf.c
+++ b/lib/analysis/modules/ies_enkf.c
@@ -38,7 +38,7 @@
 #include <ert/analysis/enkf_linalg.hpp>
 #include <ert/analysis/std_enkf.hpp>
 
-#include <ies_enkf_config.h>
+#include "ies_enkf_config.h"
 
 typedef struct ies_enkf_data_struct ies_enkf_data_type;
 

--- a/lib/analysis/modules/ies_enkf_config.c
+++ b/lib/analysis/modules/ies_enkf_config.c
@@ -37,7 +37,7 @@
 #define DEFAULT_GAUSS_NEWTON_CONV      0.0001
 
 #define DEFAULT_IES_SUBSPACE           false
-#define DEFAULT_IES_INVERSION               1
+#define DEFAULT_IES_INVERSION          IES_INVERSION_SUBSPACE_EXACT_R
 #define DEFAULT_IES_LOGFILE            "ies.log"
 #define DEFAULT_IES_DEBUG              false
 
@@ -131,10 +131,10 @@ void ies_enkf_config_set_gauss_newton_conv( ies_enkf_config_type * config , doub
 
 /*------------------------------------------------------------------------------------------------*/
 /* IES_INVERSION          */
-int ies_enkf_config_get_ies_inversion( ies_enkf_config_type * config ) {
+ies_inversion_type ies_enkf_config_get_ies_inversion( ies_enkf_config_type * config ) {
    return config->ies_inversion;
 }
-void ies_enkf_config_set_ies_inversion( ies_enkf_config_type * config , int ies_inversion ) {
+void ies_enkf_config_set_ies_inversion( ies_enkf_config_type * config , ies_inversion_type ies_inversion ) {
    config->ies_inversion = ies_inversion;
 }
 

--- a/lib/analysis/modules/ies_enkf_config.c
+++ b/lib/analysis/modules/ies_enkf_config.c
@@ -62,7 +62,7 @@ struct ies_enkf_config_struct {
 ies_enkf_config_type * ies_enkf_config_alloc() {
   ies_enkf_config_type * config = util_malloc( sizeof * config );
   UTIL_TYPE_ID_INIT( config , IES_ENKF_CONFIG_TYPE_ID );
-  config->ies_logfile = NULL; 
+  config->ies_logfile = NULL;
   ies_enkf_config_set_truncation( config , DEFAULT_ENKF_TRUNCATION);
   ies_enkf_config_set_enkf_subspace_dimension( config , DEFAULT_ENKF_SUBSPACE_DIMENSION);
   ies_enkf_config_set_option_flags( config , ANALYSIS_NEED_ED + ANALYSIS_UPDATE_A + ANALYSIS_ITERABLE + ANALYSIS_SCALE_DATA);
@@ -163,8 +163,8 @@ char * ies_enkf_config_get_ies_logfile( ies_enkf_config_type * config ) {
    return config->ies_logfile;
 }
 void ies_enkf_config_set_ies_logfile( ies_enkf_config_type * config , const char * ies_logfile ) {
-   config->ies_logfile = util_realloc_string_copy( config->ies_logfile , ies_logfile ); 
-//   config->ies_logfile = util_alloc_string_copy( ies_logfile ); 
+   config->ies_logfile = util_realloc_string_copy( config->ies_logfile , ies_logfile );
+//   config->ies_logfile = util_alloc_string_copy( ies_logfile );
 }
 
 /*------------------------------------------------------------------------------------------------*/

--- a/lib/analysis/modules/ies_enkf_config.h
+++ b/lib/analysis/modules/ies_enkf_config.h
@@ -19,6 +19,8 @@
 #ifndef IES_ENKF_CONFIG_H
 #define IES_ENKF_CONFIG_H
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/analysis/modules/ies_enkf_config.h
+++ b/lib/analysis/modules/ies_enkf_config.h
@@ -26,6 +26,14 @@ extern "C" {
 #endif
 
 
+typedef enum {
+  IES_INVERSION_EXACT = 0,
+  IES_INVERSION_SUBSPACE_EXACT_R = 1,
+  IES_INVERSION_SUBSPACE_EE_R = 2,
+  IES_INVERSION_SUBSPACE_RE = 3
+} ies_inversion_type;
+
+
 typedef struct ies_enkf_config_struct ies_enkf_config_type;
 
 
@@ -50,8 +58,8 @@ typedef struct ies_enkf_config_struct ies_enkf_config_type;
   int    ies_enkf_config_get_max_gauss_newton_it( ies_enkf_config_type * config );
   void   ies_enkf_config_set_max_gauss_newton_it( ies_enkf_config_type * config , int max_gauss_newton_it);
 
-  int    ies_enkf_config_get_ies_inversion( ies_enkf_config_type * config ) ;
-  void   ies_enkf_config_set_ies_inversion( ies_enkf_config_type * config , int ies_inversion ) ;
+  ies_inversion_type ies_enkf_config_get_ies_inversion( ies_enkf_config_type * config ) ;
+  void   ies_enkf_config_set_ies_inversion( ies_enkf_config_type * config , ies_inversion_type ies_inversion ) ;
 
   bool   ies_enkf_config_get_ies_subspace( ies_enkf_config_type * config ) ;
   void   ies_enkf_config_set_ies_subspace( ies_enkf_config_type * config , bool ies_subspace ) ;

--- a/lib/analysis/modules/ies_enkf_data.c
+++ b/lib/analysis/modules/ies_enkf_data.c
@@ -1,0 +1,232 @@
+#include "ies_enkf_config.h"
+#include "ies_enkf_data.h"
+
+#include <ert/util/type_macros.hpp>
+#include <ert/util/util.h>
+
+//**********************************************
+// IES "object" data definition
+//**********************************************
+/*
+  The configuration data used by the ies_enkf module is contained in a
+  ies_enkf_data_struct instance. The data type used for the ies_enkf
+  module is quite simple; with only a few scalar variables, but there
+  are essentially no limits to what you can pack into such a datatype.
+
+  All the functions in the module have a void pointer as the first
+  argument, this will immediately be casted to an ies_enkf_data_type
+  instance, to get some type safety the UTIL_TYPE_ID system should be
+  used.
+
+  The data structure holding the data for your analysis module should
+  be created and initialized by a constructor, which should be
+  registered with the '.alloc' element of the analysis table; in the
+  same manner the desctruction of this data should be handled by a
+  destructor or free() function registered with the .freef field of
+  the analysis table.
+*/
+
+#define IES_ENKF_DATA_TYPE_ID 6635831
+
+
+struct ies_enkf_data_struct {
+   UTIL_TYPE_ID_DECLARATION;
+   int       iteration_nr;            // Keep track of the outer iteration loop
+   double    ies_steplength;          // Step length in Gauss Newton iteration
+   double    gauss_newton_conv;       // NOT USED
+   bool      ies_subspace;            // NOT USED
+   int       max_gauss_newton_it;     // NOT USED
+   int state_size;                    // Initial state_size used for checks in subsequent calls
+   bool_vector_type * ens_mask0;      // Initial ensemble mask of active realizations
+   bool_vector_type * ens_mask;       // Ensemble mask of active realizations
+   bool_vector_type * obs_mask0;      // Initial observation mask for active measurements
+   bool_vector_type * obs_mask;       // Current observation mask
+   matrix_type * W;                   // Coefficient matrix used to compute Omega = I + W (I -11'/N)/sqrt(N-1)
+   matrix_type * A0;                  // Prior ensemble used in Ei=A0 Omega_i
+   matrix_type * E;                   // Prior ensemble of measurement perturations (should be the same for all iterations)
+   bool      converged;               // GN has converged
+   ies_enkf_config_type * config;     // This I don't understand but I assume I include data from the ies_enkf_config_type defined in ies_enkf_config.c
+   bool      AAprojection;            // For including the AAprojection of Y
+   FILE*     log_fp;                  // logfile id
+};
+
+UTIL_SAFE_CAST_FUNCTION( ies_enkf_data , IES_ENKF_DATA_TYPE_ID )
+UTIL_SAFE_CAST_FUNCTION_CONST( ies_enkf_data , IES_ENKF_DATA_TYPE_ID )
+
+void * ies_enkf_data_alloc( rng_type * rng) {
+  ies_enkf_data_type * data = util_malloc( sizeof * data);
+  UTIL_TYPE_ID_INIT( data , IES_ENKF_DATA_TYPE_ID );
+  data->iteration_nr         = 0;
+  data->ies_steplength       = 0.0;
+  data->gauss_newton_conv    = 0.0;
+  data->max_gauss_newton_it  = 0;
+  data->state_size           = 0;
+  data->ens_mask0            = NULL;
+  data->ens_mask             = NULL;
+  data->obs_mask0            = NULL;
+  data->obs_mask             = NULL;
+  data->W                    = NULL;
+  data->A0                   = NULL;
+  data->E                    = NULL;
+  data->converged            = false;
+  data->config               = ies_enkf_config_alloc();
+  data->AAprojection         = true;
+  data->log_fp               = NULL;
+  return data;
+}
+
+void ies_enkf_data_free( void * arg ) {
+  ies_enkf_data_type * data = ies_enkf_data_safe_cast( arg );
+  ies_enkf_config_free( data->config );
+  free( data );
+}
+
+void ies_enkf_data_set_iteration_nr( ies_enkf_data_type * data , int iteration_nr) {
+  data->iteration_nr = iteration_nr;
+}
+
+int ies_enkf_data_inc_iteration_nr( ies_enkf_data_type * data) {
+  data->iteration_nr++;
+  return data->iteration_nr;
+}
+
+int ies_enkf_data_get_iteration_nr( const ies_enkf_data_type * data ) {
+  return data->iteration_nr;
+}
+
+
+const ies_enkf_config_type* ies_enkf_data_get_config(const ies_enkf_data_type * data) {
+  return data->config;
+}
+
+
+
+void ies_enkf_data_update_ens_mask(ies_enkf_data_type * data, const bool_vector_type * ens_mask) {
+  if (data->ens_mask)
+    bool_vector_free(data->ens_mask);
+
+  data->ens_mask = bool_vector_alloc_copy( ens_mask );
+}
+
+
+void ies_enkf_store_initial_obs_mask(ies_enkf_data_type * data, const bool_vector_type * obs_mask) {
+  if (!data->obs_mask0)
+    data->obs_mask0 = bool_vector_alloc_copy(obs_mask);
+}
+
+void ies_enkf_update_obs_mask(ies_enkf_data_type * data, const bool_vector_type * obs_mask) {
+  if (!data->obs_mask)
+    bool_vector_free(data->obs_mask);
+
+  data->obs_mask = bool_vector_alloc_copy(obs_mask);
+}
+
+int ies_enkf_data_get_obs_mask_size(const ies_enkf_data_type * data) {
+  return bool_vector_size( data->obs_mask );
+}
+
+int ies_enkf_data_active_obs_count(const ies_enkf_data_type * data) {
+  int nrobs_msk = ies_enkf_data_get_obs_mask_size( data );
+  int nrobs = 0;
+  for (int i = 0; i < nrobs_msk; i++) {
+    if ( bool_vector_iget(data->obs_mask0,i) && bool_vector_iget(data->obs_mask,i) ){
+      nrobs=nrobs+1;
+    }
+  }
+  return nrobs;
+}
+
+
+int ies_enkf_data_get_ens_mask_size(const ies_enkf_data_type * data) {
+  return bool_vector_size(data->ens_mask);
+}
+
+
+void ies_enkf_data_update_state_size(ies_enkf_data_type * data, int state_size) {
+  if (data->state_size == 0)
+    data->state_size = state_size;
+}
+
+FILE * ies_enkf_data_open_log(ies_enkf_data_type * data) {
+  const char * ies_logfile = ies_enkf_config_get_ies_logfile( data->config );
+  FILE * fp;
+  if (data->iteration_nr == 1){
+    fp = fopen(ies_logfile, "w");
+  } else {
+      fp = fopen(ies_logfile, "a");
+  }
+  data->log_fp = fp;
+  return fp;
+}
+
+void ies_enkf_data_fclose_log(ies_enkf_data_type * data) {
+  fflush(data->log_fp);
+  fclose(data->log_fp);
+}
+
+
+void ies_enkf_data_store_initialE(ies_enkf_data_type * data, const matrix_type * E0) {
+  if (!data->E){
+    // We store the initial observation perturbations corresponding to data->obs_mask0.
+    bool dbg = ies_enkf_config_get_ies_debug( data->config ) ;
+    fprintf(data->log_fp,"Allocating and assigning data->E \n");
+    data->E = matrix_alloc_copy(E0);
+    if (dbg)
+      matrix_pretty_fprint(data->E,"data->E","%11.5f",data->log_fp);
+  }
+}
+
+void ies_enkf_data_store_initialA(ies_enkf_data_type * data, const matrix_type * A) {
+  if (!data->A0){
+    // We store the initial ensemble to use it in final update equation                     (Line 11)
+    bool dbg = ies_enkf_config_get_ies_debug( data->config ) ;
+    fprintf(data->log_fp,"Allocating and assigning data->A0 \n");
+    data->A0 = matrix_alloc_copy(A);
+    if (dbg)
+      matrix_pretty_fprint(data->A0,"Ini data->A0","%11.5f",data->log_fp);
+  }
+}
+
+
+
+void ies_enkf_data_allocateW(ies_enkf_data_type * data, int ens_size) {
+  if (!data->W){
+    // We initialize data-W which will store W for use in next iteration                    (Line 9)
+    bool dbg = ies_enkf_config_get_ies_debug( data->config ) ;
+    fprintf(data->log_fp,"Allocating data->W\n");
+    data->W=matrix_alloc(ens_size , ens_size);
+    matrix_set(data->W , 0.0) ;
+    if (dbg)
+      matrix_pretty_fprint(data->W,"Ini data->W","%11.5f",data->log_fp);
+  }
+}
+
+const bool_vector_type * ies_enkf_data_get_obs_mask0( const ies_enkf_data_type * data) {
+  return data->obs_mask0;
+}
+
+const bool_vector_type * ies_enkf_data_get_obs_mask( const ies_enkf_data_type * data) {
+  return data->obs_mask;
+}
+
+const bool_vector_type * ies_enkf_data_get_ens_mask( const ies_enkf_data_type * data) {
+  return data->ens_mask;
+}
+
+
+
+const matrix_type * ies_enkf_data_getE(const ies_enkf_data_type * data) {
+  return data->E;
+}
+
+const matrix_type * ies_enkf_data_getW(const ies_enkf_data_type * data) {
+  return data->W;
+}
+
+const matrix_type * ies_enkf_data_getA0(const ies_enkf_data_type * data) {
+  return data->A0;
+}
+
+bool ies_enkf_data_get_AAprojection(const ies_enkf_data_type * data) {
+  return data->AAprojection;
+}

--- a/lib/analysis/modules/ies_enkf_data.h
+++ b/lib/analysis/modules/ies_enkf_data.h
@@ -1,0 +1,52 @@
+#ifndef IES_ENKF_DATA_H
+#define IES_ENKF_DATA_H
+
+#include <ert/util/rng.hpp>
+#include <ert/res_util/matrix.hpp>
+#include <ert/util/bool_vector.hpp>
+#include <ert/util/type_macros.hpp>
+
+#include "ies_enkf_config.h"
+
+
+typedef struct ies_enkf_data_struct ies_enkf_data_type;
+
+void * ies_enkf_data_alloc( rng_type * rng);
+void ies_enkf_data_free( void * arg );
+
+void ies_enkf_data_set_iteration_nr( ies_enkf_data_type * data , int iteration_nr);
+int ies_enkf_data_get_iteration_nr( const ies_enkf_data_type * data );
+int ies_enkf_data_inc_iteration_nr( ies_enkf_data_type * data);
+
+const ies_enkf_config_type* ies_enkf_data_get_config(const ies_enkf_data_type * data);
+
+void ies_enkf_data_update_ens_mask(ies_enkf_data_type * data, const bool_vector_type * ens_mask);
+void ies_enkf_store_initial_obs_mask(ies_enkf_data_type * data, const bool_vector_type * obs_mask);
+void ies_enkf_update_obs_mask(ies_enkf_data_type * data, const bool_vector_type * obs_mask);
+void ies_enkf_data_update_state_size( ies_enkf_data_type * data, int state_size);
+
+int ies_enkf_data_get_obs_mask_size(const ies_enkf_data_type * data);
+int ies_enkf_data_get_ens_mask_size(const ies_enkf_data_type * data);
+int ies_enkf_data_active_obs_count(const ies_enkf_data_type * data);
+
+const bool_vector_type * ies_enkf_data_get_obs_mask0( const ies_enkf_data_type * data);
+const bool_vector_type * ies_enkf_data_get_obs_mask( const ies_enkf_data_type * data);
+const bool_vector_type * ies_enkf_data_get_ens_mask( const ies_enkf_data_type * data);
+
+FILE * ies_enkf_data_open_log(ies_enkf_data_type * data);
+void ies_enkf_data_fclose_log(ies_enkf_data_type * data);
+
+void ies_enkf_data_allocateW(ies_enkf_data_type * data, int ens_size);
+void ies_enkf_data_store_initialE(ies_enkf_data_type * data, const matrix_type * E0);
+void ies_enkf_data_store_initialA(ies_enkf_data_type * data, const matrix_type * A);
+const matrix_type * ies_enkf_data_getE(const ies_enkf_data_type * data);
+const matrix_type * ies_enkf_data_getW(const ies_enkf_data_type * data);
+const matrix_type * ies_enkf_data_getA0(const ies_enkf_data_type * data);
+
+bool ies_enkf_data_get_AAprojection(const ies_enkf_data_type * data);
+
+UTIL_SAFE_CAST_HEADER(ies_enkf_data);
+UTIL_SAFE_CAST_HEADER_CONST(ies_enkf_data);
+
+
+#endif

--- a/lib/analysis/modules/tecplot.c
+++ b/lib/analysis/modules/tecplot.c
@@ -1,0 +1,141 @@
+void static teccost(const matrix_type * W,
+             const matrix_type * D,
+             const char * fname,
+             const int ens_size,
+             const int izone)
+{
+   FILE *fp;
+   float costJ[100];
+
+   if (izone == 1){
+      fp = fopen(fname, "w");
+      fprintf(fp, "TITLE = \"%s\"\n",fname);
+      fprintf(fp, "VARIABLES = \"i\" \"Average J\" ");
+      for (int i = 0; i < ens_size; i++)
+         fprintf(fp, "\"%d\" ",i);
+      fprintf(fp,"\n");
+   } else {
+      fp = fopen(fname, "a");
+   }
+
+   float costf=0.0;
+   for (int i = 0; i < ens_size; i++){
+      costJ[i]=matrix_column_column_dot_product(W,i,W,i)+matrix_column_column_dot_product(D,i,D,i);
+      costf += costJ[i];
+   }
+   costf= costf/ens_size;
+
+   fprintf(fp,"%2d %10.3f ", izone-1, costf) ;
+   for (int i = 0; i < ens_size; i++)
+      fprintf(fp,"%10.3f ", costJ[i] ) ;
+   fprintf(fp,"\n") ;
+   fclose(fp);
+}
+
+void static teclog(const matrix_type * W,
+            const matrix_type * D,
+            const matrix_type * DW,
+            const char * fname,
+            const int ens_size,
+            const int itnr,
+            const double rcond,
+            const int nrsing,
+            const int nrobs)
+{
+
+   double diff1W = 0.0;
+   double diff2W = 0.0;
+   double diffW;
+   double costfp,costfd,costf;
+   FILE *fp;
+
+   if (itnr == 1){
+      fp = fopen(fname, "w");
+      fprintf(fp, "TITLE = \"%s\"\n",fname);
+      fprintf(fp, "VARIABLES = \"it\" \"Diff1W\" \"Diff2W\" \"J-prior\" \"J-data\" \"J\" \"rcond\" \"Sing\" \"nrobs\"\n");
+   } else {
+      fp = fopen(fname, "a");
+   }
+
+   for (int i = 0; i < ens_size; i++){
+       diffW=matrix_column_column_dot_product(DW,i,DW,i)/ens_size;
+       diff2W+=diffW;
+       if (diffW > diff1W) diff1W=diffW ;
+   }
+   diff2W=diff2W/ens_size;
+
+   costfp=0.0;
+   costfd=0.0;
+   for (int i = 0; i < ens_size; i++){
+       costfp += matrix_column_column_dot_product(W,i,W,i);
+       costfd += matrix_column_column_dot_product(D,i,D,i);
+   }
+   costfp=costfp/ens_size;
+   costfd=costfd/ens_size;
+   costf= costfp + costfd;
+   fprintf(fp," %d %12.5e %12.5e %12.5e %12.5e %12.5e %12.5e %d %d\n", itnr-1, diff1W, diff2W, costfp, costfd, costf, rcond, nrsing , nrobs ) ;
+   fclose(fp);
+}
+
+void static tecfld(const matrix_type * W,
+           const char * fname,
+           const char * vname,
+           int idim,
+           int jdim,
+           int izone)
+{
+   FILE *fp;
+
+   if (izone == 1){
+      fp = fopen(fname, "w");
+      fprintf(fp, "TITLE = \"%s\"\n",fname);
+      fprintf(fp, "VARIABLES = \"i-index\" \"j-index\" \"%s\"\n",vname);
+      fprintf(fp, "ZONE F=BLOCK, T=\"Iteration %d\", I=%d, J=%d, K=1\n",izone, idim, jdim);
+      {
+         int ic=0;
+         for (int j=0;j<jdim;j++){
+            for (int i=0;i<idim;i++){
+               ic=ic+1;
+               fprintf(fp,"%d ",i);
+               if (ic==30){
+                  ic=0;
+                  fprintf(fp,"\n");
+               }
+            }
+         }
+      }
+
+      {
+         int ic=0;
+         for (int j=0;j<jdim;j++){
+            for (int i=0;i<idim;i++){
+               ic=ic+1;
+               fprintf(fp,"%d ",j);
+               if (ic==30){
+                  ic=0;
+                  fprintf(fp,"\n");
+               }
+            }
+         }
+      }
+   } else {
+      fp = fopen(fname, "a");
+      fprintf(fp, "ZONE F=BLOCK, T=\"Iteration %d\", I=%d, J=%d, K=1, VARSHARELIST = ([1,2]=1)",izone, idim, jdim);
+   }
+
+   {
+      int ic=0;
+      for (int j=0;j<jdim;j++){
+         for (int i=0;i<idim;i++){
+            ic=ic+1;
+            fprintf(fp,"%12.5e ",matrix_iget(W , i,j));
+            if (ic==30){
+               ic=0;
+               fprintf(fp,"\n");
+            }
+         }
+      }
+   }
+   fclose(fp);
+}
+

--- a/lib/analysis/modules/tests/ies_enkf.c
+++ b/lib/analysis/modules/tests/ies_enkf.c
@@ -1,0 +1,7 @@
+#include <ert/util/test_util.hpp>
+
+#include "ies_enkf_data.h"
+#include "ies_enkf_config.h"
+
+int main(int argc, char ** argv) {
+}

--- a/lib/analysis/modules/tests/ies_enkf_config.c
+++ b/lib/analysis/modules/tests/ies_enkf_config.c
@@ -1,0 +1,15 @@
+#include <ert/util/test_util.hpp>
+
+#include "ies_enkf_data.h"
+#include "ies_enkf_config.h"
+
+
+void test_create() {
+  ies_enkf_config_type * config = ies_enkf_config_alloc();
+
+  ies_enkf_config_free(config);
+}
+
+int main(int argc, char ** argv) {
+  test_create();
+}

--- a/lib/analysis/modules/tests/ies_enkf_data.c
+++ b/lib/analysis/modules/tests/ies_enkf_data.c
@@ -1,0 +1,20 @@
+#include <ert/util/test_util.hpp>
+
+#include <ert/util/rng.h>
+
+#include "ies_enkf_data.h"
+#include "ies_enkf_config.h"
+
+
+void test_create() {
+  rng_type * rng = rng_alloc( MZRAN, INIT_DEFAULT );
+  ies_enkf_data_type * data = ies_enkf_data_alloc(rng);
+  test_assert_not_NULL(data);
+  ies_enkf_data_free( data );
+  rng_free( rng );
+}
+
+
+int main(int argc, char ** argv) {
+  test_create();
+}

--- a/lib/analysis/modules/tests/ies_enkf_module.c
+++ b/lib/analysis/modules/tests/ies_enkf_module.c
@@ -1,0 +1,12 @@
+#include <ert/util/test_util.hpp>
+
+#include <ert/analysis/analysis_module.hpp>
+
+
+
+int main(int argc, char ** argv) {
+  const char * module_lib = argv[1];
+  analysis_module_type * module = analysis_module_alloc_external( module_lib );
+  test_assert_not_NULL( module );
+  analysis_module_free( module );
+}


### PR DESCRIPTION
The purpose of this is to split things up bit, to simplify testing. The important changes are in commits -3 and -2:

**Extracted ies_enkf_data to separate file:** The ies implementation contains three high-level objects:

1. The algorithms in `ies_enkf.c` - the `ies_enkf.c` file should only have algorithms, and *no state*.
2. The file `ies_enkf_data.c` contains state which is controlled by the algorithm itself - i.e. mask of active observation and realisations and so on.
3. The file `ies_enkf_config.c` contains state which is controlled by the user.

The main content of this commit is to extract everything related to the algorithm specific state to the new file `ies_enkf_data.c`. As part of that process some new accessor functions to set/get state properties in the `ies_enkf_data` structure has been added.

Also observe that many members have been removed from the `ies_enkf_data` struct; a pattern which was quite pervasive was:
```C
int some_var = ies_enkf_config_get_initial_var( config );
data->some_var = some_var;

data->some_var = some_function(some_var);

// Code which uses data->some_var
```

This has been replaced with:
```C
int some_var = ies_enkf_config_get_initial_var( config );
some_var = some_function( some_var );

// Code which uses local variable some_var
```
i.e. `some_var` is *not* retained in the `ies_enkf_data` state object; state (and large temporal/spatial scopes) is the root of much evil - here it can be avoided.

**Add basic instantiation tests for ies** 
Some small (very) basic tests have been added for the different structures in the ies implementation.


In addition the building of the `ies` module is intergrated with the normal build system in the first commit.
